### PR TITLE
Make widget scripts load in correct order in dj2.2

### DIFF
--- a/mezzanine/core/admin.py
+++ b/mezzanine/core/admin.py
@@ -36,6 +36,7 @@ if settings.USE_MODELTRANSLATION:
         """
         class Media:
             js = (
+                'admin/js/jquery.init.js',
                 static("modeltranslation/js/force_jquery.js"),
                 static("mezzanine/js/admin/tabbed_translation_fields.js"),
             )

--- a/mezzanine/core/forms.py
+++ b/mezzanine/core/forms.py
@@ -43,11 +43,18 @@ class TinyMceWidget(forms.Textarea):
     use TinyMCE.
     """
 
-    class Media:
-        js = [static("mezzanine/tinymce/tinymce.min.js"),
-              static("mezzanine/tinymce/jquery.tinymce.min.js"),
-              static(settings.TINYMCE_SETUP_JS)]
+    @property
+    def media(self):
+        extra = '' if settings.DEBUG else '.min'
+        js = [
+            'admin/js/vendor/jquery/jquery%s.js' % extra,
+            'admin/js/jquery.init.js',
+            static("mezzanine/tinymce/tinymce.min.js"),
+            static("mezzanine/tinymce/jquery.tinymce.min.js"),
+            static(settings.TINYMCE_SETUP_JS),
+        ]
         css = {'all': [static("mezzanine/tinymce/tinymce.css")]}
+        return forms.Media(js=js, css=css)
 
     def __init__(self, *args, **kwargs):
         super(TinyMceWidget, self).__init__(*args, **kwargs)
@@ -79,8 +86,11 @@ class DynamicInlineAdminForm(forms.ModelForm):
     """
 
     class Media:
-        js = [static("mezzanine/js/%s" % settings.JQUERY_UI_FILENAME),
-              static("mezzanine/js/admin/dynamic_inline.js")]
+        js = [
+            'admin/js/jquery.init.js',
+            static("mezzanine/js/%s" % settings.JQUERY_UI_FILENAME),
+            static("mezzanine/js/admin/dynamic_inline.js")
+        ]
 
 
 class SplitSelectDateTimeWidget(forms.SplitDateTimeWidget):

--- a/mezzanine/generic/forms.py
+++ b/mezzanine/generic/forms.py
@@ -33,7 +33,10 @@ class KeywordsWidget(forms.MultiWidget):
     """
 
     class Media:
-        js = (static("mezzanine/js/admin/keywords_field.js"),)
+        js = (
+            'admin/js/jquery.init.js',
+            static("mezzanine/js/admin/keywords_field.js"),
+        )
 
     def __init__(self, attrs=None):
         """


### PR DESCRIPTION
Make all admin widget which rely on window.jQuery load jquery.init.js and all that rely on window.django.jQuery also load jquery.js as per 2.2 upgrade instructions

Django 2.2 does a topological sort of dependencies, meaning widget have to be more careful about specifying their dependencies. It seems the current assumption is that on the admin window.jQuery is Mezzanine's jQuery (1.xx) and that django.jQuery is Django's jQuery (3.xx). However, the way widget javascripts are now merged (topological sort) can mean that we end up with scripts loaded in the order 1) Django jquery.js 2) our widget script 3) Django jquery.init.js . This means that our widget script will see window.jQuery as Django's version of jQuery rather than Mezzanine's.

For the sake of consistency, this PR makes sure that all widgets with scripts which rely on window.jQuery load jquery.init.js and all that rely on window.django.jQuery also load jquery.js.

(I came across this discrepancy while trying to fix another bug. It turns out it is not the cause, however I think this change would be prudent.)

Sources:
https://docs.djangoproject.com/en/2.2/releases/2.2/#merging-of-form-media-assets
https://groups.google.com/forum/#!topic/django-users/scJvRttmQZY