### PR TITLE
Disable required on TinyMceWidget textareas, allowing forms with required fields to submit on dj2.2

### DIFF
--- a/mezzanine/core/forms.py
+++ b/mezzanine/core/forms.py
@@ -53,6 +53,11 @@ class TinyMceWidget(forms.Textarea):
         super(TinyMceWidget, self).__init__(*args, **kwargs)
         self.attrs["class"] = "mceEditor"
 
+    def use_required_attribute(self, initial):
+        # TinyMCE does not put content back into the <textarea>, so we want to
+        # allow it to submit when empty.
+        return False
+
 
 class OrderWidget(forms.HiddenInput):
     """


### PR DESCRIPTION
TinyMCE does not put content back into the <textarea>, so we want to
allow it to submit when empty. Currently a form with a required field
with a TinyMceWidget would be impossible to submit and no error would
show since the textarea has been hidden.