### PR TITLE
WIP

### DIFF
--- a/mezzanine/core/admin.py
+++ b/mezzanine/core/admin.py
@@ -301,7 +301,8 @@ class ContentTypedAdmin(object):
                       self.model._meta.many_to_many)
             for field in reversed(fields):
                 if field.name not in exclude_fields and field.editable:
-                    if not hasattr(field, "translated_field"):
+                    if not hasattr(field, "translated_field") and field.name \
+                             not in self.fieldsets[0][1]["fields"]:
                         self.fieldsets[0][1]["fields"].insert(3, field.name)
 
     @property

--- a/mezzanine/core/middleware.py
+++ b/mezzanine/core/middleware.py
@@ -170,7 +170,7 @@ class UpdateCacheMiddleware(MiddlewareMixin):
         context = RequestContext(request)
         for i, part in enumerate(parts):
             if i % 2:
-                part = Template(part).render(context).encode("utf-8")
+                part = Template(part.decode('utf-8')).render(context).encode("utf-8")
             parts[i] = part
         response.content = b"".join(parts)
         response["Content-Length"] = len(response.content)


### PR DESCRIPTION
Just a couple of pointers for errors I have found when porting a heavy application to Django 2.2, just in case it saves some time for others:

* Escaped chars appearing in html when using nevercache tag
* Duplicated fields in admin