### PR TITLE
Rename admin CSS class "field-box" to "fieldBox".

### DIFF
--- a/mezzanine/core/static/mezzanine/css/admin/global.css
+++ b/mezzanine/core/static/mezzanine/css/admin/global.css
@@ -210,7 +210,7 @@ body.popup .breadcrumbs + ul.messagelist {
 fieldset.module {
     margin-bottom: 25px;
 }
-fieldset .field-box {
+fieldset .fieldBox {
     margin: 0 150px 10px 0 !important;
 }
 .form-row label + p.datetime {

--- a/mezzanine/core/static/mezzanine/css/admin/rtl.css
+++ b/mezzanine/core/static/mezzanine/css/admin/rtl.css
@@ -94,7 +94,7 @@ ul.messagelist {
     margin: -1px 0 0 6px;
 }
 
-fieldset .field-box {
+fieldset .fieldBox {
     margin-right: 0 !important;
     margin-left: 150px !important;
 }


### PR DESCRIPTION
In Django 2.1, [the CSS class "field-box" was renamed to "fieldBox"](https://github.com/django/django/commit/5d4d62bf4fe887fcd30f9f0449de07ae76ea5968) to address [Django bug #29248](https://code.djangoproject.com/ticket/29248).  This patch, in conjuction with an equivalent patch for the grappelli-safe repo, incorporates this change into Mezzanine.

Without this patch, models that have multiple fields set to display on the same line via their `fields` or `fieldsets` definitions are no longer rendered correctly in Mezzanine's admin when running on Django >= 2.1.  (The example Mezzanine site contents do not rely on any models that do this, so this error is not immediately apparent on simple test sites.)

It should be noted that this patch breaks backwards compatibility with Django 1.11.