### PR TITLE
Fix calls to formfield_for_dbfield()

### DIFF
--- a/mezzanine/pages/admin.py
+++ b/mezzanine/pages/admin.py
@@ -161,14 +161,14 @@ class LinkAdmin(PageAdmin):
 
     fieldsets = link_fieldsets
 
-    def formfield_for_dbfield(self, db_field, **kwargs):
+    def formfield_for_dbfield(self, db_field, request, **kwargs):
         """
         Make slug mandatory.
         """
         if db_field.name == "slug":
             kwargs["required"] = True
             kwargs["help_text"] = None
-        return super(LinkAdmin, self).formfield_for_dbfield(db_field, **kwargs)
+        return super(LinkAdmin, self).formfield_for_dbfield(db_field, request, **kwargs)
 
     def save_form(self, request, form, change):
         """

--- a/mezzanine/twitter/admin.py
+++ b/mezzanine/twitter/admin.py
@@ -28,7 +28,7 @@ class TweetableAdminMixin(object):
     to the object being saved.
     """
 
-    def formfield_for_dbfield(self, db_field, **kwargs):
+    def formfield_for_dbfield(self, db_field, request, **kwargs):
         """
         Adds the "Send to Twitter" checkbox after the "status" field,
         provided by any ``Displayable`` models. The approach here is
@@ -38,7 +38,7 @@ class TweetableAdminMixin(object):
         horrifically.
         """
         formfield = super(TweetableAdminMixin,
-            self).formfield_for_dbfield(db_field, **kwargs)
+            self).formfield_for_dbfield(db_field, request, **kwargs)
         if Api and db_field.name == "status" and get_auth_settings():
             def wrapper(render):
                 def wrapped(*args, **kwargs):


### PR DESCRIPTION
`formfield_for_dbfield()` takes a `request` argument post Django 1.8. I ran [this issue](https://github.com/deschler/django-modeltranslation/issues/514) as well so added it in this patch.

Thanks a lot for the 2.2 branch btw, I'm testing it now ☺️ .